### PR TITLE
Feature/0242-1 - Client: Form Fields components

### DIFF
--- a/src/assets/Icons/arrow_drop_down_blue-24px.svg
+++ b/src/assets/Icons/arrow_drop_down_blue-24px.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="5" viewBox="0 0 10 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0L5 5L10 0H0Z" fill="#2E66E6"/>
+</svg>

--- a/src/components/FormField/FormField.jsx
+++ b/src/components/FormField/FormField.jsx
@@ -1,0 +1,63 @@
+const FormField = ({input}) => {
+  {/* 
+    Usage:
+    
+    1. import the component (e.g. import "../FormField/FormField.scss";)
+    2. Create an element by using the code below
+
+    <FormField input={{
+      label: "",
+      class: "", // modifiers. (e.g. error)
+      type: "", // choices: dropdown, input, search
+      name: "", 
+      value: "",
+      // onChange: "", // function name
+
+      // options - used only for [type:"dropdown"], otherwise remove this
+      options: [
+        { value: "1", label: "Option 1" },
+        { value: "2", label: "Option 2" },
+      ]
+      }}
+    />
+  */}
+
+  return (
+    <>
+      <div className="form__group">
+        <label className="form-label" htmlFor={input.name}>{input.label}</label>
+        {input.type === "dropdown" ? (
+          <select
+            className={`form-input ${input.class}`}
+            id={input.name}
+            name={input.name}
+            defaultValue={input.value}
+            onChange={input.onChange}
+          >
+            {input.options?.map((option, index) => (
+              <option key={index} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            className={`form-input ${input.class}`}
+            type={input.type}
+            id={input.name}
+            name={input.name}
+            placeholder={input.placeholder}
+            defaultValue={input.value}
+            onChange={input.onChange}
+          />
+        )}
+        
+        {input.class.includes('error') && (
+          <span className="error">This field is required</span>
+        )}
+      </div>
+    </>
+  );
+}
+ 
+export default FormField;

--- a/src/components/FormField/FormField.scss
+++ b/src/components/FormField/FormField.scss
@@ -1,0 +1,77 @@
+@use "../../styles/partials/variables" as *;
+
+.form__group {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  margin: 0.5rem 0 1rem;
+
+  .form-input {
+    transition: $transition-active-input;
+    margin: 0.5rem 0;
+
+    &::placeholder {
+      color: $instock-slate;
+      font-size: 14px;
+    }
+
+    &[type="search"] {
+      appearance: none;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      background-color: transparent;
+      background-image: url("../../assets/Icons/search-24px.svg");
+      background-repeat: no-repeat;
+      background-position: right 10px center;
+      background-size: 24px;
+    }
+
+    &:focus {
+      border-color: $instock-blue;
+    }
+
+    &.error {
+      border-color: $instock-red;
+    }
+  }
+}
+
+select.form-input {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: transparent;
+  background-image: url("../../assets/Icons/arrow_drop_down-24px.svg");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 24px;
+
+  &:focus {
+    background-image: url("../../assets/Icons/arrow_drop_down_blue-24px.svg");
+    background-repeat: no-repeat;
+    background-position: right 17px center;
+    background-size: 10px;
+  }
+}
+
+span {
+  &.error {
+    display: inline-flex;
+    align-items: center;
+    color: $instock-red;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+
+    &::before {
+      content: '';
+      display: inline-block;
+      width: 1rem;
+      height: 1rem;
+      margin-right: 5px;
+      background-image: url('../../assets/Icons/error-24px.svg'); // Path to your SVG
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+  }
+}

--- a/src/styles/partials/_variables.scss
+++ b/src/styles/partials/_variables.scss
@@ -28,3 +28,5 @@ $outofstock-tagbg: #c9451537;
 // Hover background
 $instock-hoverblue: #004bfa;
 
+// ------------------------------ Transition ------------------------------
+$transition-active-input: border 0.35s ease;


### PR DESCRIPTION
- Create a new reusable component `Form Field`
- Uploaded a new icon (blue arrow down) for Dropdown's active state
- Created border transition for input's transitions

How to use FormField Component:
1. import the component (e.g. import "../FormField/FormField.scss";)
2. Create an element by using the code below

```
<FormField input={{
  label: "",
  class: "", // modifiers. (e.g. error)
  type: "", // choices: dropdown, input, search
  name: "", 
  value: "",
  // onChange: "", // function name

  // options - used only for [type:"dropdown"], otherwise remove this
  options: [
    { value: "1", label: "Option 1" },
    { value: "2", label: "Option 2" },
  ]
  }}
/>
```