### PR TITLE
Fixes issue with incorrect colon in Link component on Warehouse List page.

### DIFF
--- a/src/components/WarehouseList/WarehouseList.jsx
+++ b/src/components/WarehouseList/WarehouseList.jsx
@@ -152,7 +152,7 @@ const WarehouseList = () => {
                   <>
                     <tr className="table-data" key={index}>
                       <td>
-                        <Link to={`/warehouse/:${warehouse.id}`}>
+                        <Link to={`/warehouse/${warehouse.id}`}>
                         <span className="warehouse-name">
                           {warehouse.warehouse_name}
                         </span>


### PR DESCRIPTION
this issue causes the id extracted from useParams() to have a colon before the id itself which causes problem when the id is used for axios call.