### PR TITLE
Fix rendering of in-stock/out-of-stock badge and

### DIFF
--- a/src/components/ItemDetails/ItemDetails.jsx
+++ b/src/components/ItemDetails/ItemDetails.jsx
@@ -62,11 +62,11 @@ const ItemDetails = () => {
           <div className="status_quantity-wrapper">
             <div>
               <p className="item-label">STATUS:</p>
-              {itemData.quantity > 0 ? <InStockTag /> : <OutOfStockTag />}
+              {itemData.status === "In Stock" ? <InStockTag /> : <OutOfStockTag />}
             </div>
             <div>
               <p className="item-label">QUANTITY:</p>
-              {itemData.quantity}
+              {itemData.status === "In Stock" ? itemData.quantity : 0}
             </div>
           </div>
 


### PR DESCRIPTION
**Update includes:**

Fix: Dynamic Badge and Quantity Rendering in Item Details
Resolved an issue where the In Stock / Out of Stock status badge and the corresponding item quantity in the item details page were not updating correctly when the item status was changed.
Now, both the badge and quantity fields reflect real-time changes based on the item's updated status, ensuring accurate UI feedback.

